### PR TITLE
Add endpoint to get all user reserved blocks

### DIFF
--- a/api/src/main/java/com/codeforcommunity/api/IBlockProcessor.java
+++ b/api/src/main/java/com/codeforcommunity/api/IBlockProcessor.java
@@ -12,4 +12,6 @@ public interface IBlockProcessor {
   BlockResponse releaseBlocks(JWTData jwtData, List<String> blockIds);
 
   BlockResponse resetBlocks(JWTData jwtData, List<String> blockIds);
+
+  List<String> getUserReservedBlocks(JWTData jwtData, boolean includeDone);
 }

--- a/api/src/main/java/com/codeforcommunity/rest/RestFunctions.java
+++ b/api/src/main/java/com/codeforcommunity/rest/RestFunctions.java
@@ -56,4 +56,9 @@ public interface RestFunctions {
     }
     throw new MissingParameterException(name);
   }
+
+  static boolean getRequestParameterAsBoolean(HttpServerRequest req, String name) {
+    String paramValue = req.getParam(name);
+    return Boolean.parseBoolean(paramValue);
+  }
 }

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/BlocksRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/BlocksRouter.java
@@ -104,9 +104,7 @@ public class BlocksRouter implements IRouter {
 
   private void handleGetReserved(RoutingContext ctx) {
     JWTData userData = ctx.get("jwt_data");
-
-    boolean includeDone =
-        ctx.queryParams().contains("done") && Boolean.parseBoolean(ctx.queryParams().get("done"));
+    boolean includeDone = RestFunctions.getRequestParameterAsBoolean(ctx.request(), "done");
 
     List<String> response = processor.getUserReservedBlocks(userData, includeDone);
 

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/BlocksRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/BlocksRouter.java
@@ -1,5 +1,7 @@
 package com.codeforcommunity.rest.subrouter;
 
+import static com.codeforcommunity.rest.ApiRouter.end;
+
 import com.codeforcommunity.api.IBlockProcessor;
 import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dto.blocks.BlockResponse;
@@ -12,10 +14,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
-
 import java.util.List;
-
-import static com.codeforcommunity.rest.ApiRouter.end;
 
 public class BlocksRouter implements IRouter {
 
@@ -106,7 +105,8 @@ public class BlocksRouter implements IRouter {
   private void handleGetReserved(RoutingContext ctx) {
     JWTData userData = ctx.get("jwt_data");
 
-    boolean includeDone = ctx.queryParams().contains("done") && Boolean.parseBoolean(ctx.queryParams().get("done"));
+    boolean includeDone =
+        ctx.queryParams().contains("done") && Boolean.parseBoolean(ctx.queryParams().get("done"));
 
     List<String> response = processor.getUserReservedBlocks(userData, includeDone);
 

--- a/api/src/main/java/com/codeforcommunity/rest/subrouter/BlocksRouter.java
+++ b/api/src/main/java/com/codeforcommunity/rest/subrouter/BlocksRouter.java
@@ -1,7 +1,5 @@
 package com.codeforcommunity.rest.subrouter;
 
-import static com.codeforcommunity.rest.ApiRouter.end;
-
 import com.codeforcommunity.api.IBlockProcessor;
 import com.codeforcommunity.auth.JWTData;
 import com.codeforcommunity.dto.blocks.BlockResponse;
@@ -9,10 +7,15 @@ import com.codeforcommunity.dto.blocks.StandardBlockRequest;
 import com.codeforcommunity.rest.IRouter;
 import com.codeforcommunity.rest.RestFunctions;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+
+import java.util.List;
+
+import static com.codeforcommunity.rest.ApiRouter.end;
 
 public class BlocksRouter implements IRouter {
 
@@ -30,6 +33,7 @@ public class BlocksRouter implements IRouter {
     registerFinish(router);
     registerRelease(router);
     registerReset(router);
+    registerGetReserved(router);
 
     return router;
   }
@@ -52,6 +56,11 @@ public class BlocksRouter implements IRouter {
   private void registerReset(Router router) {
     Route reserveRoute = router.post("/reset");
     reserveRoute.handler(this::handleResetRoute);
+  }
+
+  private void registerGetReserved(Router router) {
+    Route reserveRoute = router.get("/reserved");
+    reserveRoute.handler(this::handleGetReserved);
   }
 
   private void handleReserveRoute(RoutingContext ctx) {
@@ -92,5 +101,15 @@ public class BlocksRouter implements IRouter {
     BlockResponse response = processor.resetBlocks(userData, blockRequest.getBlocks());
 
     end(ctx.response(), 200, JsonObject.mapFrom(response).encode());
+  }
+
+  private void handleGetReserved(RoutingContext ctx) {
+    JWTData userData = ctx.get("jwt_data");
+
+    boolean includeDone = ctx.queryParams().contains("done") && Boolean.parseBoolean(ctx.queryParams().get("done"));
+
+    List<String> response = processor.getUserReservedBlocks(userData, includeDone);
+
+    end(ctx.response(), 200, new JsonArray(response).encode());
   }
 }

--- a/service/src/main/java/com/codeforcommunity/processor/BlocksProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/BlocksProcessorImpl.java
@@ -8,12 +8,10 @@ import com.codeforcommunity.dto.blocks.BlockResponse;
 import com.codeforcommunity.enums.BlockStatus;
 import com.codeforcommunity.enums.PrivilegeLevel;
 import com.codeforcommunity.requester.MapRequester;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import org.jooq.DSLContext;
 import org.jooq.Result;
 import org.jooq.generated.tables.records.BlockRecord;
@@ -105,7 +103,9 @@ public class BlocksProcessorImpl implements IBlockProcessor {
 
   @Override
   public List<String> getUserReservedBlocks(JWTData jwtData, boolean includeDone) {
-    return getUserReservedBlocks(jwtData.getUserId(), includeDone).stream().map(BlockRecord::getFid).collect(Collectors.toList());
+    return getUserReservedBlocks(jwtData.getUserId(), includeDone).stream()
+        .map(BlockRecord::getFid)
+        .collect(Collectors.toList());
   }
 
   /**
@@ -115,9 +115,7 @@ public class BlocksProcessorImpl implements IBlockProcessor {
     return db.selectFrom(BLOCK).where(BLOCK.FID.in(blockIds)).fetchGroups(BLOCK.STATUS);
   }
 
-  /**
-   * Get the list of block ids from the given Map that are not in the correct state.
-   */
+  /** Get the list of block ids from the given Map that are not in the correct state. */
   private List<String> getInvalidBlockStatusIds(
       Map<BlockStatus, Result<BlockRecord>> blocks, BlockStatus validBlockStatus) {
     List<String> failures = new ArrayList<>();
@@ -183,8 +181,10 @@ public class BlocksProcessorImpl implements IBlockProcessor {
 
   /**
    * Returns all blocks that are reserved by a user.
+   *
    * @param userId the ID of the user.
-   * @param includeDone if true, returns all blocks that are "RESERVED" or "DONE", else only returns "RESERVED" blocks
+   * @param includeDone if true, returns all blocks that are "RESERVED" or "DONE", else only returns
+   *     "RESERVED" blocks
    * @return A list of BlockRecord that are assigned to the given user.
    */
   private List<BlockRecord> getUserReservedBlocks(int userId, boolean includeDone) {

--- a/service/src/main/java/com/codeforcommunity/processor/BlocksProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/BlocksProcessorImpl.java
@@ -184,14 +184,20 @@ public class BlocksProcessorImpl implements IBlockProcessor {
   /**
    * Returns all blocks that are reserved by a user.
    * @param userId the ID of the user.
-   * @param includeDone if true, returns all blocks that are NOT "OPEN", else only returns "RESERVED" blocks
-   * @return
+   * @param includeDone if true, returns all blocks that are "RESERVED" or "DONE", else only returns "RESERVED" blocks
+   * @return A list of BlockRecord that are assigned to the given user.
    */
   private List<BlockRecord> getUserReservedBlocks(int userId, boolean includeDone) {
     if (includeDone) {
-      return db.selectFrom(BLOCK).where(BLOCK.STATUS.notEqual(BlockStatus.OPEN)).and(BLOCK.ASSIGNED_TO.equal(userId)).fetch();
+      return db.selectFrom(BLOCK)
+          .where(BLOCK.STATUS.equal(BlockStatus.RESERVED).or(BLOCK.STATUS.equal(BlockStatus.DONE)))
+          .and(BLOCK.ASSIGNED_TO.equal(userId))
+          .fetch();
     } else {
-      return db.selectFrom(BLOCK).where(BLOCK.STATUS.equal(BlockStatus.RESERVED)).and(BLOCK.ASSIGNED_TO.equal(userId)).fetch();
+      return db.selectFrom(BLOCK)
+          .where(BLOCK.STATUS.equal(BlockStatus.RESERVED))
+          .and(BLOCK.ASSIGNED_TO.equal(userId))
+          .fetch();
     }
   }
 }


### PR DESCRIPTION
 - Add endpoint `GET /api/v1/protected/blocks/reserved` to return all blocks that are `assigned_to` the current user and have a status of `RESERVED`
  - Including query param `done=true` will also return all blocks withs status `DONE`
  - Returns a list of `block.fid`