### PR TITLE
Clean up unnecessary generic type usage

### DIFF
--- a/service/src/main/java/com/codeforcommunity/processor/TeamsProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/TeamsProcessorImpl.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.jooq.DSLContext;
 import org.jooq.Field;
-import org.jooq.Record;
+import org.jooq.Record5;
 import org.jooq.Result;
 import org.jooq.generated.tables.pojos.Team;
 import org.jooq.generated.tables.pojos.Users;
@@ -248,7 +248,7 @@ public class TeamsProcessorImpl implements ITeamsProcessor {
   }
 
   private List<TeamMember> getTeamMembers(int teamId) {
-    Result<?> userResult =
+    Result<Record5<Integer, String, BigDecimal, BigDecimal, TeamRole>> userResult =
         db.select(
                 USERS.ID,
                 USERS.USERNAME,
@@ -269,13 +269,13 @@ public class TeamsProcessorImpl implements ITeamsProcessor {
 
     List<TeamMember> teamMembers = new ArrayList<>();
 
-    for (Record record : userResult) {
+    for (Record5<Integer, String, BigDecimal, BigDecimal, TeamRole> record : userResult) {
       teamMembers.add(
           new TeamMember(
               record.getValue(USERS.ID),
               record.getValue(USERS.USERNAME),
-              ((BigDecimal) record.getValue("blocksCompleted")).intValue(),
-              ((BigDecimal) record.getValue("blocksReserved")).intValue(),
+              record.value3().intValue(),
+              record.value4().intValue(),
               record.getValue(USER_TEAM.TEAM_ROLE)));
     }
     return teamMembers;


### PR DESCRIPTION
A generic typing was used when not needed, and values were casted to a different type to interact with them. This PR removes that by using a concrete generic class.