### PR TITLE
BM - Implement Soft Deletes

### DIFF
--- a/persist/src/main/resources/db/migration/V5__SoftDeletes.sql
+++ b/persist/src/main/resources/db/migration/V5__SoftDeletes.sql
@@ -1,0 +1,9 @@
+ALTER TABLE users
+ADD COLUMN deleted BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE users
+    ADD COLUMN deleted_timestamp timestamp;
+ALTER TABLE team
+    ADD COLUMN deleted BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE team
+    ADD COLUMN deleted_timestamp timestamp;
+

--- a/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
+++ b/service/src/main/java/com/codeforcommunity/dataaccess/AuthDatabaseOperations.java
@@ -53,7 +53,9 @@ public class AuthDatabaseOperations {
   public JWTData getUserJWTData(String email) {
     Optional<Users> maybeUser =
         Optional.ofNullable(
-            db.selectFrom(USERS).where(USERS.EMAIL.eq(email)).fetchOneInto(Users.class));
+            db.selectFrom(USERS)
+                .where(USERS.EMAIL.eq(email), USERS.DELETED.isFalse())
+                .fetchOneInto(Users.class));
 
     if (maybeUser.isPresent()) {
       Users user = maybeUser.get();
@@ -71,7 +73,10 @@ public class AuthDatabaseOperations {
    */
   public Users getUserPojo(int id) {
     Optional<Users> maybeUser =
-        Optional.ofNullable(db.selectFrom(USERS).where(USERS.ID.eq(id)).fetchOneInto(Users.class));
+        Optional.ofNullable(
+            db.selectFrom(USERS)
+                .where(USERS.ID.eq(id), USERS.DELETED.isFalse())
+                .fetchOneInto(Users.class));
 
     if (maybeUser.isPresent()) {
       return maybeUser.get();
@@ -87,7 +92,9 @@ public class AuthDatabaseOperations {
   public boolean isValidLogin(String email, String pass) {
     Optional<Users> maybeUser =
         Optional.ofNullable(
-            db.selectFrom(USERS).where(USERS.EMAIL.eq(email)).fetchOneInto(Users.class));
+            db.selectFrom(USERS)
+                .where(USERS.EMAIL.eq(email), USERS.DELETED.isFalse())
+                .fetchOneInto(Users.class));
 
     return maybeUser
         .filter(user -> Passwords.isExpectedPassword(pass, user.getPassHash()))
@@ -103,11 +110,14 @@ public class AuthDatabaseOperations {
    */
   public UsersRecord createNewUser(
       String username, String email, String password, String firstName, String lastName) {
-    boolean emailUsed = db.fetchExists(db.selectFrom(USERS).where(USERS.EMAIL.eq(email)));
+    boolean emailUsed =
+        db.fetchExists(db.selectFrom(USERS).where(USERS.EMAIL.eq(email), USERS.DELETED.isFalse()));
     if (emailUsed) {
       throw new EmailAlreadyInUseException(email);
     }
-    boolean usernameUsed = db.fetchExists(db.selectFrom(USERS).where(USERS.USERNAME.eq(username)));
+    boolean usernameUsed =
+        db.fetchExists(
+            db.selectFrom(USERS).where(USERS.USERNAME.eq(username), USERS.DELETED.isFalse()));
     if (usernameUsed) {
       throw new UsernameAlreadyInUseException(username);
     }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedUserProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedUserProcessorImpl.java
@@ -78,7 +78,7 @@ public class ProtectedUserProcessorImpl implements IProtectedUserProcessor {
   public void changePassword(JWTData userData, ChangePasswordRequest changePasswordRequest) {
     UsersRecord user = db.selectFrom(USERS).where(USERS.ID.eq(userData.getUserId())).fetchOne();
 
-    if (user == null) {
+    if (user == null || user.getDeleted()) {
       throw new UserDoesNotExistException(userData.getUserId());
     }
 
@@ -98,7 +98,7 @@ public class ProtectedUserProcessorImpl implements IProtectedUserProcessor {
   public UserDataResponse getUserData(JWTData userData) {
     UsersRecord user = db.selectFrom(USERS).where(USERS.ID.eq(userData.getUserId())).fetchOne();
 
-    if (user == null) {
+    if (user == null || user.getDeleted()) {
       throw new UserDoesNotExistException(userData.getUserId());
     }
 
@@ -109,7 +109,7 @@ public class ProtectedUserProcessorImpl implements IProtectedUserProcessor {
   @Override
   public void changeEmail(JWTData userData, ChangeEmailRequest changeEmailRequest) {
     UsersRecord user = db.selectFrom(USERS).where(USERS.ID.eq(userData.getUserId())).fetchOne();
-    if (user == null) {
+    if (user == null || user.getDeleted()) {
       throw new UserDoesNotExistException(userData.getUserId());
     }
 
@@ -133,7 +133,7 @@ public class ProtectedUserProcessorImpl implements IProtectedUserProcessor {
   @Override
   public void changeUsername(JWTData userData, ChangeUsernameRequest changeUsernameRequest) {
     UsersRecord user = db.selectFrom(USERS).where(USERS.ID.eq(userData.getUserId())).fetchOne();
-    if (user == null) {
+    if (user == null || user.getDeleted()) {
       throw new UserDoesNotExistException(userData.getUserId());
     }
 

--- a/service/src/main/java/com/codeforcommunity/processor/TeamsProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/TeamsProcessorImpl.java
@@ -35,6 +35,7 @@ import com.codeforcommunity.exceptions.UserNotOnTeamException;
 import com.codeforcommunity.requester.Emailer;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -256,7 +257,11 @@ public class TeamsProcessorImpl implements ITeamsProcessor {
 
     db.deleteFrom(USER_TEAM).where(USER_TEAM.TEAM_ID.eq(teamId)).execute();
 
-    db.deleteFrom(TEAM).where(TEAM.ID.eq(teamId)).execute();
+    db.update(TEAM)
+        .set(TEAM.DELETED, true)
+        .set(TEAM.DELETED_TIMESTAMP, Timestamp.from(Instant.now()))
+        .where(TEAM.ID.eq(teamId))
+        .execute();
   }
 
   @Override


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/702429655/pulses/742442213)


## This PR

- Added columns `deleted` and `deleted_timestamp` to the Users and Team tables

- Removed hard delete functionality from the protected user processor and team processor implementation 

- Replaced the above with soft delete functionality, where the deleted entity's deleted value is switched to TRUE, and the deleted timestamp is updated to the current time

## Verification Steps

Be sure to run mvn clean install to update database

For User
1. Create a test user (either by hitting the API or in the database
2. Delete them by hitting the API
3. Check the database and make sure their deleted column is set to true and that the timestamp is the current time
4. If the user was a team leader make sure the team they led also has it's deleted column set to true and that it's deleted timestamp is current

For Team
1. Create a test user 
2. Using that user make a new team by hitting the API
3. Verify that the team is in the database
4. Delete the team by hitting the API's protected teams route
5. Verify that within the database that team's deleted column is set to true and that the timestamp is the current time