### PR TITLE
Implementing Soft Deletes

### DIFF
--- a/persist/src/main/resources/db/migration/V5__SoftDeletes.sql
+++ b/persist/src/main/resources/db/migration/V5__SoftDeletes.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS deleted_users
+(
+    id                SERIAL PRIMARY KEY,
+    first_name        VARCHAR(36),
+    last_name         VARCHAR(36),
+    username          VARCHAR(36),
+    email             VARCHAR(36) UNIQUE NOT NULL,
+    pass_hash         BYTEA              NOT NULL,
+    privilege_level   INTEGER            NOT NULL DEFAULT 0,
+    email_verified    BOOLEAN                     DEFAULT false,
+    deleted_timestamp TIMESTAMP          NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS deleted_team
+(
+    id                   SERIAL PRIMARY KEY,
+    name                 VARCHAR(36) NOT NULL,
+    bio                  TEXT        NOT NULL,
+    goal                 INT,
+    goal_completion_date TIMESTAMP,
+    created_timestamp    TIMESTAMP   NOT NULL,
+    deleted_timestamp    TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedUserProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedUserProcessorImpl.java
@@ -1,5 +1,6 @@
 package com.codeforcommunity.processor;
 
+import static org.jooq.generated.Tables.DELETED_TEAM;
 import static org.jooq.generated.Tables.DELETED_USERS;
 import static org.jooq.generated.Tables.TEAM;
 import static org.jooq.generated.Tables.USERS;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import org.jooq.DSLContext;
 import org.jooq.generated.tables.pojos.Users;
+import org.jooq.generated.tables.records.TeamRecord;
 import org.jooq.generated.tables.records.UserTeamRecord;
 import org.jooq.generated.tables.records.UsersRecord;
 
@@ -53,7 +55,10 @@ public class ProtectedUserProcessorImpl implements IProtectedUserProcessor {
           db.deleteFrom(USER_TEAM)
               .where(USER_TEAM.TEAM_ID.eq(userTeamRecord.getTeamId()))
               .executeAsync();
-          db.deleteFrom(TEAM).where(TEAM.ID.eq(userTeamRecord.getTeamId())).executeAsync();
+          TeamRecord team =
+              db.selectFrom(TEAM).where(TEAM.ID.eq(userTeamRecord.getTeamId())).fetchOne();
+          db.insertInto(DELETED_TEAM).set(team.intoMap());
+          team.delete();
         } else {
           db.executeDelete(userTeamRecord, USER_TEAM.USER_ID.eq(userId));
         }

--- a/service/src/main/java/com/codeforcommunity/processor/ProtectedUserProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/ProtectedUserProcessorImpl.java
@@ -1,5 +1,6 @@
 package com.codeforcommunity.processor;
 
+import static org.jooq.generated.Tables.DELETED_USERS;
 import static org.jooq.generated.Tables.TEAM;
 import static org.jooq.generated.Tables.USERS;
 import static org.jooq.generated.Tables.USER_TEAM;
@@ -60,6 +61,8 @@ public class ProtectedUserProcessorImpl implements IProtectedUserProcessor {
     }
 
     UsersRecord user = db.selectFrom(USERS).where(USERS.ID.eq(userId)).fetchOne();
+
+    db.insertInto(DELETED_USERS).set(user.intoMap()).execute();
     user.delete();
 
     emailer.sendAccountDeactivatedEmail(

--- a/service/src/main/java/com/codeforcommunity/processor/TeamsProcessorImpl.java
+++ b/service/src/main/java/com/codeforcommunity/processor/TeamsProcessorImpl.java
@@ -1,6 +1,7 @@
 package com.codeforcommunity.processor;
 
 import static org.jooq.generated.Tables.BLOCK;
+import static org.jooq.generated.Tables.DELETED_TEAM;
 import static org.jooq.generated.Tables.TEAM;
 import static org.jooq.generated.Tables.USERS;
 import static org.jooq.generated.Tables.USER_TEAM;
@@ -256,7 +257,10 @@ public class TeamsProcessorImpl implements ITeamsProcessor {
 
     db.deleteFrom(USER_TEAM).where(USER_TEAM.TEAM_ID.eq(teamId)).execute();
 
-    db.deleteFrom(TEAM).where(TEAM.ID.eq(teamId)).execute();
+    TeamRecord team = db.selectFrom(TEAM).where(TEAM.ID.eq(teamId)).fetchOne();
+    db.insertInto(DELETED_TEAM).set(team.intoMap()).execute();
+
+    team.delete();
   }
 
   @Override


### PR DESCRIPTION
## Why

[Monday.com Ticket](https://code4community-team.monday.com/boards/702429655/pulses/742442213)


## This PR

- Added deleted_users and deleted_team table

- Now, when a user or team is deleted, It will be placed into its respective deleted table

## Verification Steps

Be sure to run mvn clean install to update database (you may need to re-run it just on the persist step)

For User
1. Create a test user (either by hitting the API or in the database
2. Delete them by hitting the API
3. Check the database and make sure the user was deleted from the users table and that the user is now in the deleted_users table with a deleted_timestamp matching the current time
4. If the user was a team leader make sure the team they led is also gone

For Team
1. Create a test user 
2. Using that user make a new team by hitting the API
3. Verify that the team is in the database
4. Delete the team by hitting the API's protected teams route
5. Verify that within the database that team is deleted and is now a record in the deleted_team table 